### PR TITLE
Upcoming Events Card Redone

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,10 +2,18 @@
 import JoinUS from "@/components/home/JoinUs";
 import FindUs from "@/components/home/FindUs";
 import Landing from "@/components/home/Landing";
+import UpcomingEvents from "@/components/home/UpcomingEvents";
 const Home = () => {
   return (
     <div className="flex h-full w-screen flex-col items-center justify-center">
       <Landing />
+      <UpcomingEvents
+        date="month, day"
+        time="12:34 PM"
+        loc="@location"
+        text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+        color="vsa-pink-300"
+      />
       <JoinUS />
       <FindUs />
     </div>

--- a/src/components/home/UpcomingEvents.tsx
+++ b/src/components/home/UpcomingEvents.tsx
@@ -1,0 +1,38 @@
+interface CardProps {
+  date: string;
+  time: string;
+  loc: string;
+  text: string;
+  color: string;
+}
+
+const Card = ({ date, time, loc, text, color }: CardProps) => {
+  return (
+    <div className="border-vsa-brown flex w-1/5 flex-col items-center justify-center overflow-hidden rounded-lg border-2 bg-white">
+      <div
+        className={`bg-${color} border-vsa-brown h-1/3 w-full justify-center border-b-2 p-4 text-left`}
+      >
+        <p className="text-md font-vsa-main text-vsa-yellow-200 text-outline justify-center text-center text-4xl font-extrabold">
+          {date}
+        </p>
+      </div>
+
+      <div className="h-1/3 w-full justify-center p-1 text-left">
+        <p className="font-vsa-alt text-vsa-brown justify-center text-center">
+          {time}
+        </p>
+        <p className="font-vsa-alt text-vsa-brown justify-center text-center">
+          {loc}
+        </p>
+      </div>
+
+      <div className="bg-vsa-pink-300 my-2 h-[2px] w-8"></div>
+
+      <div className="w-full rounded-b-lg p-2 text-center">
+        <p className="font-vsa-alt text-vsa-brown text-sm">{text}</p>
+      </div>
+    </div>
+  );
+};
+
+export default Card;


### PR DESCRIPTION
<img width="399" height="421" alt="Screenshot 2025-10-31 at 1 22 21 AM" src="https://github.com/user-attachments/assets/1b8bb0df-0c39-448b-ae29-f74e63eb2b9e" />

Republishing fresh branch with Upcoming Events Card

Resolves #50

Review of changes:

1. Top section color (under "month, day") passed in as prop